### PR TITLE
Remove dev proxy and standardize API base URL

### DIFF
--- a/src/config/api.js
+++ b/src/config/api.js
@@ -1,0 +1,16 @@
+const DEFAULT_BASE_URL = 'https://kau-capstone.duckdns.org';
+
+export const API_BASE_URL = (import.meta.env?.VITE_API_BASE_URL || DEFAULT_BASE_URL).replace(/\/$/, '');
+
+export const resolveApiUrl = (path = '') => {
+  if (!path) {
+    return API_BASE_URL;
+  }
+
+  if (/^https?:\/\//i.test(path)) {
+    return path;
+  }
+
+  const normalizedPath = path.startsWith('/') ? path : `/${path}`;
+  return `${API_BASE_URL}${normalizedPath}`;
+};

--- a/src/pages/Market.jsx
+++ b/src/pages/Market.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useMemo, useEffect } from 'react';
 import { ShoppingBag, AlertCircle, Loader2 } from 'lucide-react';
 import { cachedFetch, apiCache } from '../utils/apiCache';
+import { API_BASE_URL, resolveApiUrl } from '../config/api';
 import { FilterBar } from '../components/market/FilterBar';
 import { ModelCard } from '../components/market/ModelCard';
 import { ComparisonBar } from '../components/market/ComparisonBar';
@@ -9,15 +10,13 @@ import { ComparisonOverlay } from '../components/market/ComparisonOverlay';
 // API 서비스 함수
 const apiService = {
   // 환경변수 기반 baseURL 설정
-  baseURL: '',
-  
+  baseURL: API_BASE_URL,
+
   async fetchModels(forceRefresh = false) {
     try {
       // 환경에 따른 API URL 생성
-      const apiUrl = import.meta.env.NODE_ENV === 'development' 
-        ? `/api/models`  // 개발환경: 프록시 사용
-        : `${this.baseURL}/api/models`;  // 프로덕션: 직접 호출
-      
+      const apiUrl = resolveApiUrl('/api/models');
+
       console.log('Environment:', import.meta.env.NODE_ENV);
       console.log('Base URL:', this.baseURL);
       console.log('API 요청 URL:', apiUrl);

--- a/src/pages/ModelDetail.jsx
+++ b/src/pages/ModelDetail.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { useParams, Link } from 'react-router-dom';
 import { cachedFetch } from '../utils/apiCache';
+import { resolveApiUrl } from '../config/api';
 import { 
   Star, 
   Download, 
@@ -23,10 +24,11 @@ const modelDetailService = {
   async fetchModel(id, forceRefresh = false) {
     try {
       // 쿼리 파라미터 방식으로 변경
-      const apiUrl = `/api/models?id=${id}`;
-      
+      const apiPath = `/api/models?id=${id}`;
+      const apiUrl = resolveApiUrl(apiPath);
+
       console.log('Model detail API 요청 URL:', apiUrl);
-      
+
       const data = await cachedFetch(apiUrl, {
         method: 'GET',
         headers: {

--- a/src/pages/Personal.jsx
+++ b/src/pages/Personal.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useRef } from 'react';
-import { 
-  Plus, 
-  Bot, 
+import {
+  Plus,
+  Bot,
   Database, 
   Upload, 
   Eye, 
@@ -16,6 +16,7 @@ import {
   X
 } from 'lucide-react';
 import { Link } from 'react-router-dom';
+import { resolveApiUrl } from '../config/api';
 
 export const Personal = () => {
   const [activeTab, setActiveTab] = useState('overview');
@@ -24,7 +25,7 @@ export const Personal = () => {
   const [formStep, setFormStep] = useState(1); // 1: 타입선택, 2: 모델폼, 3: 데이터셋폼
 
   // 모델 업로드 관련 상태
-  const API_BASE = '/api';
+  const API_BASE = resolveApiUrl('/api');
   const modelFileInputRef = useRef(null);
   const [modelFile, setModelFile] = useState(null);
   const [modelStatus, setModelStatus] = useState('');

--- a/src/utils/apiCache.js
+++ b/src/utils/apiCache.js
@@ -1,3 +1,5 @@
+import { resolveApiUrl } from '../config/api';
+
 // API 캐싱 유틸리티
 class ApiCache {
   constructor() {
@@ -81,7 +83,8 @@ export const apiCache = new ApiCache();
 // 캐시된 fetch 함수
 export const cachedFetch = async (url, options = {}, ttl) => {
   const { forceRefresh = false, ...fetchOptions } = options;
-  const cacheKey = apiCache.generateKey(url, fetchOptions);
+  const finalUrl = resolveApiUrl(url);
+  const cacheKey = apiCache.generateKey(finalUrl, fetchOptions);
 
   // 강제 새로고침이 아닌 경우 캐시 확인
   if (!forceRefresh) {
@@ -92,8 +95,8 @@ export const cachedFetch = async (url, options = {}, ttl) => {
   }
 
   try {
-    console.log(`Fetching from API: ${url}`);
-    const response = await fetch(url, fetchOptions);
+    console.log(`Fetching from API: ${finalUrl}`);
+    const response = await fetch(finalUrl, fetchOptions);
     
     if (!response.ok) {
       throw new Error(`HTTP ${response.status}: ${response.statusText}`);

--- a/vite.config.js
+++ b/vite.config.js
@@ -12,14 +12,4 @@ export default defineConfig({
   optimizeDeps: {
     exclude: ['lucide-react'],
   },
-  server: {
-    proxy: {
-      '/api': {
-        target: 'https://kau-capstone.duckdns.org/',
-        changeOrigin: true,
-        // 필요하면:
-        // rewrite: (path) => path.replace(/^\/api/, '/api'),
-      },
-    },
-  },
 });


### PR DESCRIPTION
## Summary
- remove the Vite dev-server proxy now that the backend allows direct HTTPS access
- centralize the API base URL resolution and update cached fetch logic to build absolute endpoints
- update pages using API calls to rely on the new helper and direct backend URLs

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e32a018ae48332aaa02ccfa74e9ef0