### PR TITLE
Update frontend to match new model API schema

### DIFF
--- a/src/components/market/ComparisonOverlay.jsx
+++ b/src/components/market/ComparisonOverlay.jsx
@@ -1,11 +1,31 @@
 import React from 'react';
-import { X, ExternalLink } from 'lucide-react';
+import { X } from 'lucide-react';
 import { Link } from 'react-router-dom';
 
 export const ComparisonOverlay = ({ models, onClose, onRemove }) => {
   if (models.length === 0) return null;
 
-  const allMetrics = [...new Set(models.flatMap(model => Object.keys(model.metrics)))];
+  const allMetrics = [
+    ...new Set(
+      models.flatMap(model =>
+        (model.metricDisplay || model.metricHighlights || []).map(metric => metric.key || metric.label)
+      )
+    )
+  ];
+
+  const resolveMetricInfo = (metricKey) => {
+    for (const model of models) {
+      const metric = (model.metricDisplay || model.metricHighlights || []).find(
+        item => item.key === metricKey || item.label === metricKey
+      );
+
+      if (metric) {
+        return metric;
+      }
+    }
+
+    return { label: metricKey, formattedValue: '-', description: '' };
+  };
 
   return (
     <div className="fixed inset-0 z-50 overflow-hidden">
@@ -65,18 +85,33 @@ export const ComparisonOverlay = ({ models, onClose, onRemove }) => {
               ))}
 
               {/* Metrics */}
-              {allMetrics.map(metric => (
-                <React.Fragment key={metric}>
-                  <div className="font-medium text-gray-700 py-3 capitalize">{metric}</div>
-                  {models.map(model => (
-                    <div key={`${model.id}-${metric}`} className="py-3">
-                      <div className="text-sm font-semibold text-gray-900">
-                        {model.metrics[metric] ? `${model.metrics[metric]}%` : '-'}
-                      </div>
+              {allMetrics.map(metricKey => {
+                const info = resolveMetricInfo(metricKey);
+
+                return (
+                  <React.Fragment key={metricKey}>
+                    <div className="font-medium text-gray-700 py-3">
+                      <div className="text-sm text-gray-900">{info.label}</div>
+                      {info.description && (
+                        <div className="text-xs text-gray-500 mt-1">{info.description}</div>
+                      )}
                     </div>
-                  ))}
-                </React.Fragment>
-              ))}
+                    {models.map(model => {
+                      const metric = (model.metricDisplay || model.metricHighlights || []).find(
+                        item => item.key === metricKey || item.label === metricKey
+                      );
+
+                      return (
+                        <div key={`${model.id}-${metricKey}`} className="py-3">
+                          <div className="text-sm font-semibold text-gray-900">
+                            {metric ? metric.formattedValue : '-'}
+                          </div>
+                        </div>
+                      );
+                    })}
+                  </React.Fragment>
+                );
+              })}
 
               {/* Actions */}
               <div className="font-medium text-gray-700 py-3">액션</div>

--- a/src/components/market/ModelCard.jsx
+++ b/src/components/market/ModelCard.jsx
@@ -12,6 +12,7 @@ export const ModelCard = ({
       case 'LLM': return 'bg-blue-100 text-blue-800';
       case 'VLM': return 'bg-purple-100 text-purple-800';
       case '이미지': return 'bg-green-100 text-green-800';
+      case '오디오': return 'bg-orange-100 text-orange-800';
       default: return 'bg-gray-100 text-gray-800';
     }
   };
@@ -26,8 +27,13 @@ export const ModelCard = ({
     }
   };
 
-  // Get top 2 metrics only
-  const topMetrics = Object.entries(model.metrics).slice(0, 2);
+  const metricHighlights = Array.isArray(model.metricHighlights) && model.metricHighlights.length > 0
+    ? model.metricHighlights
+    : Object.entries(model.metrics).slice(0, 2).map(([key, value]) => ({
+        key,
+        label: key,
+        formattedValue: typeof value === 'number' ? value.toString() : String(value),
+      }));
 
   return (
     <div className="bg-white rounded-xl border border-gray-200 p-6 hover:shadow-lg hover:border-gray-300 transition-all duration-200 group">
@@ -59,10 +65,10 @@ export const ModelCard = ({
 
       {/* Top 2 Metrics Only */}
       <div className="grid grid-cols-2 gap-3 mb-4">
-        {topMetrics.map(([metric, value]) => (
-          <div key={metric} className="text-center p-3 bg-gray-50 rounded-lg">
-            <div className="text-xs text-gray-600 mb-1 uppercase font-medium">{metric}</div>
-            <div className="text-lg font-bold text-gray-900">{value}%</div>
+        {metricHighlights.map((metric) => (
+          <div key={metric.key || metric.label} className="text-center p-3 bg-gray-50 rounded-lg">
+            <div className="text-xs text-gray-600 mb-1 uppercase font-medium truncate">{metric.label}</div>
+            <div className="text-lg font-bold text-gray-900">{metric.formattedValue}</div>
           </div>
         ))}
       </div>

--- a/src/utils/modelTransformers.js
+++ b/src/utils/modelTransformers.js
@@ -24,7 +24,7 @@ const MODALITY_LABELS = {
 
 export const MODEL_DEFAULT_THUMBNAIL = 'https://images.pexels.com/photos/8386440/pexels-photo-8386440.jpeg';
 
-const normalizeKey = (value) =>
+export const normalizeKey = (value) =>
   (value ?? '')
     .toString()
     .trim()
@@ -132,4 +132,189 @@ export const selectDefaultPlan = (plans) => {
   }
 
   return plans.find((plan) => plan.id === 'standard') || plans[0];
+};
+
+const METRIC_METADATA = {
+  MMLU: { label: 'MMLU', suffix: '%', decimals: 0, description: '종합 학습 평가' },
+  HELLASWAG: { label: 'HellaSwag', suffix: '%', decimals: 0, description: '상황 추론 정확도' },
+  ARC: { label: 'ARC', suffix: '%', decimals: 0, description: '과학 추론 정확도' },
+  TRUTHFULQA: { label: 'TruthfulQA', suffix: '%', decimals: 0, description: '진실성 평가' },
+  GSM8K: { label: 'GSM8K', suffix: '%', decimals: 0, description: '수학 추론 정확도' },
+  HUMANEVAL: { label: 'HumanEval', suffix: '%', decimals: 0, description: '코드 생성 정확도' },
+  FID: { label: 'FID', suffix: '', decimals: 1, description: 'Fréchet Inception Distance (낮을수록 좋음)' },
+  INCEPTIONSCORE: { label: 'Inception Score', suffix: '', decimals: 0, description: '이미지 다양성 지표' },
+  CLIPSCORE: { label: 'CLIP Score', suffix: '', decimals: 2, description: '텍스트-이미지 정합성' },
+  MME: { label: 'MME', suffix: '', decimals: 0, description: '멀티모달 종합 점수' },
+  OCR_F1: { label: 'OCR F1', suffix: '%', decimals: 0, description: '문자 인식 정확도' },
+  VQAV2: { label: 'VQAv2', suffix: '%', decimals: 0, description: '시각 질의응답 정확도' },
+  WER_KO: { label: 'WER (KO)', suffix: '%', decimals: 1, description: '한국어 음성 인식 오류율 (낮을수록 좋음)' },
+  MOS: { label: 'MOS', suffix: '', decimals: 1, description: '음질 평가 (5점 만점)' },
+  LATENCY: { label: 'Latency', suffix: 's', decimals: 1, description: '평균 지연 시간' },
+};
+
+const MODALITY_PRIORITIES = {
+  LLM: ['MMLU', 'HUMANEVAL', 'GSM8K', 'HELLASWAG', 'ARC', 'TRUTHFULQA'],
+  이미지: ['FID', 'CLIPSCORE', 'INCEPTIONSCORE'],
+  VLM: ['MME', 'OCR_F1', 'VQAV2'],
+  오디오: ['MOS', 'WER_KO', 'LATENCY'],
+};
+
+const formatMetricValue = (value, decimals = 0, suffix = '') => {
+  if (value === null || value === undefined || Number.isNaN(value)) {
+    return '-';
+  }
+
+  const factor = 10 ** decimals;
+  const rounded = Math.round(value * factor) / factor;
+  const formatted = decimals > 0 ? rounded.toFixed(decimals) : rounded.toString();
+  return `${formatted}${suffix}`;
+};
+
+export const prepareMetricDisplay = (metrics = {}, modalityLabel = '') => {
+  const entries = Object.entries(metrics)
+    .filter(([, value]) => typeof value === 'number' && Number.isFinite(value))
+    .map(([key, value]) => {
+      const normalizedKey = normalizeKey(key);
+      const metadata = METRIC_METADATA[normalizedKey] || {};
+      const decimals = metadata.decimals ?? (value < 10 ? 1 : 0);
+      const suffix = metadata.suffix ?? '';
+
+      return {
+        key,
+        normalizedKey,
+        label: metadata.label || key,
+        rawValue: value,
+        formattedValue: formatMetricValue(value, decimals, suffix),
+        description: metadata.description || '',
+      };
+    });
+
+  const priorities = MODALITY_PRIORITIES[modalityLabel] || [];
+
+  return entries.sort((a, b) => {
+    const aIndex = priorities.indexOf(a.normalizedKey);
+    const bIndex = priorities.indexOf(b.normalizedKey);
+
+    if (aIndex === -1 && bIndex === -1) {
+      return a.label.localeCompare(b.label);
+    }
+
+    if (aIndex === -1) return 1;
+    if (bIndex === -1) return -1;
+    return aIndex - bIndex;
+  });
+};
+
+export const getMetricHighlights = (metrics = {}, modalityLabel = '', limit = 3) =>
+  prepareMetricDisplay(metrics, modalityLabel).slice(0, limit);
+
+const TECH_SPEC_LABELS = {
+  CONTEXTWINDOW: '컨텍스트 윈도우',
+  MAXOUTPUTTOKENS: '최대 출력 토큰',
+  PROMPTTOKENS: '프롬프트 토큰',
+  MAXOUTPUTRESOLUTION: '최대 출력 해상도',
+  TEXTTOKENS: '텍스트 토큰',
+  MAXIMAGES: '최대 이미지 수',
+  MAXIMAGERESOLUTION: '최대 이미지 해상도',
+  MAXAUDIOINPUT: '최대 오디오 입력',
+  MAXAUDIOOUTPUT: '최대 오디오 출력',
+  SAMPLERATE: '샘플링 레이트',
+  MONTHLYTOKENLIMIT: '월 토큰 한도',
+  MONTHLYGENERATIONLIMIT: '월 생성 한도',
+  MONTHLYREQUESTLIMIT: '월 요청 한도',
+};
+
+export const formatTechnicalSpecs = (specs = {}) => {
+  if (!specs || typeof specs !== 'object') {
+    return [];
+  }
+
+  return Object.entries(specs)
+    .filter(([, value]) => value !== null && value !== undefined && value !== '')
+    .map(([key, value]) => {
+      const normalizedKey = normalizeKey(key);
+      return {
+        key,
+        label: TECH_SPEC_LABELS[normalizedKey] || key,
+        value,
+      };
+    });
+};
+
+const detectSampleType = (sample) => {
+  if (!sample) return 'text';
+  if (typeof sample === 'string') return 'text';
+
+  const keys = Object.keys(sample).map(normalizeKey);
+
+  if (keys.some((key) => key.includes('IMAGE'))) {
+    return 'image';
+  }
+
+  if (keys.some((key) => key.includes('AUDIO'))) {
+    return 'audio';
+  }
+
+  return 'text';
+};
+
+const normalizeSampleObject = (sample) => {
+  if (typeof sample === 'string') {
+    return {
+      type: 'text',
+      output: sample,
+      raw: sample,
+    };
+  }
+
+  if (!sample || typeof sample !== 'object') {
+    return null;
+  }
+
+  const type = detectSampleType(sample);
+
+  return {
+    type,
+    prompt: sample.prompt || sample.input || sample.question || '',
+    inputImage: sample.inputImage || sample.image || '',
+    outputImage: sample.outputImage || sample.imageOutput || '',
+    inputAudio: sample.inputAudio || '',
+    outputAudio: sample.outputAudio || '',
+    output: sample.output || sample.answer || sample.response || sample.outputText || '',
+    raw: sample,
+  };
+};
+
+export const normalizeSampleEntries = (model, modalityLabel = '') => {
+  const samples = [];
+
+  if (!model) {
+    return samples;
+  }
+
+  const candidates = [];
+
+  if (model.sample) {
+    candidates.push(model.sample);
+  }
+
+  if (model.samples) {
+    if (Array.isArray(model.samples)) {
+      candidates.push(...model.samples);
+    } else {
+      candidates.push(model.samples);
+    }
+  }
+
+  candidates
+    .map(normalizeSampleObject)
+    .filter(Boolean)
+    .forEach((sample, index) => {
+      samples.push({
+        ...sample,
+        id: `${modalityLabel || 'sample'}-${index}`,
+      });
+    });
+
+  return samples;
 };


### PR DESCRIPTION
## Summary
- extend model transformer utilities to format modality-specific metrics, normalize sample data, and surface technical specs
- adapt the market list and comparison UI to consume the new model list schema and display formatted metric highlights
- refresh the model detail page to render modality-aware samples, pricing metadata, and structured release notes from the new API

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e334ea83ec8332ac50ddc56e5ee543